### PR TITLE
[2021-01-11]용석: 파트너 계정 생성 처리 수정

### DIFF
--- a/src/main/java/io/auth/api/AuthApiApplication.java
+++ b/src/main/java/io/auth/api/AuthApiApplication.java
@@ -1,17 +1,12 @@
 package io.auth.api;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class AuthApiApplication {
 
-	@Bean
-	public ModelMapper modelMapper(){
-		return new ModelMapper();
-	}
+
 
 	public static void main(String[] args) {
 		SpringApplication.run(AuthApiApplication.class, args);

--- a/src/main/java/io/auth/api/config/ApplicationConfig.java
+++ b/src/main/java/io/auth/api/config/ApplicationConfig.java
@@ -1,0 +1,36 @@
+package io.auth.api.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/** 용석 : 2021-01-11
+ * Application 구동 관련 설정 부
+ */
+@Configuration
+@Slf4j
+public class ApplicationConfig {
+
+    /** 용석 : 2020-01-11
+     * 입력값을 통해 결정되거나, 시스템에서 자동으로 부여하는 항목들의 입력을 제한하기 위해
+     * 분리한 입력객체와 Entity객체를 Mapping하기 위한 ModelMapper
+     * @return : modelMapper Bean
+     */
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
+
+    /** 용석 : 2021-01-11
+     * Spring Security에서 제공하는 암호화 모듈
+     * 어떤 방식으로 암호화 됬는지 암호화 방식을 String pre-fix로 제공
+     * @return
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/io/auth/api/domain/entity/PartnerEntity.java
+++ b/src/main/java/io/auth/api/domain/entity/PartnerEntity.java
@@ -25,7 +25,6 @@ public class PartnerEntity {
     @NotBlank
     private String password;
 
-    @Column(unique = true)
     @NotBlank
     private String partnerEmail;
 

--- a/src/main/java/io/auth/api/repository/PartnerRepository.java
+++ b/src/main/java/io/auth/api/repository/PartnerRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface PartnerRepository extends JpaRepository<PartnerEntity, Long> {
     Optional<PartnerEntity> findById(String id);
+    Long countById(String id);
 }

--- a/src/main/java/io/auth/api/service/PartnerService.java
+++ b/src/main/java/io/auth/api/service/PartnerService.java
@@ -12,22 +12,48 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/** 용석:2021-01-11
+ * 제휴사 관련 기능 처리 부
+ * -> Success TC : PartnerServiceSuccessTest.java
+ * -> Fail TC : PartnerServiceFailTest.java
+ */
 @Service
 @RequiredArgsConstructor
 public class PartnerService implements UserDetailsService {
 
     private final PartnerRepository partnerRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    /** 용석
+     * 파트너 정보 생성
+     *  - 처리내용
+     *    -> SpringSecurity의 PasswordEncoder를 이용한 bcript 암호화 [기본값 : bcript]
+     *    -> {@Link ProcessingResult}객체를 이용한 처리 결과 반환
+     * @param partnerEntity
+     * @return
+     */
     public ProcessingResult createPartner(PartnerEntity partnerEntity) {
         ProcessingResult processingResult = new ProcessingResult();
         PartnerEntity createdPartnerEntity;
         try {
+            /* Partner Entity의 id 중복 검사 */
+            if(this.isDuplicatedId(partnerEntity.getId())){
+                return processingResult.processFail(Error.builder()
+                        .code(-1)
+                        .detail("ERROR Duplicated Partner")
+                        .Msg("이미 존재하는 회원입니다.")
+                        .build());
+            }
+
+            /* SpringSecurity의 PasswordEncoder를 이용한 bcript 암호화 [기본값] */
+            partnerEntity.setPassword(this.passwordEncoder.encode(partnerEntity.getPassword()));
             createdPartnerEntity = partnerRepository.save(partnerEntity);
             return processingResult.processSuccess(createdPartnerEntity);
         } catch (Exception e) {
@@ -35,16 +61,14 @@ public class PartnerService implements UserDetailsService {
             return processingResult.processFail(Error.builder()
                     .code(-1)
                     .detail(e.getMessage())
-                    .Msg("회원 가입에 실패하였습니다.")
+                    .Msg("회원 가입에 실패하였습니다. 관리자에게 문의 하세요.")
                     .build());
         }
     }
 
-//    public ProcessingResult createPartner(PartnerEntity partnerEntity){
-//        PartnerEntity createdPartnerEntity = this.partnerRepository.save(partnerEntity);
-//        ProcessingResult processingResult = new ProcessingResult();
-//        return processingResult.processSuccess(createdPartnerEntity);
-//    }
+    public boolean isDuplicatedId(String id){
+        return partnerRepository.countById(id) == 0 ? false : true;
+    }
 
     /**
      * Application에서 정의한 Account domain을 Spring security에서 정의한 UsertDetail Interface로 변환
@@ -67,8 +91,6 @@ public class PartnerService implements UserDetailsService {
          *  - UserDetails interface로 객체 변환 처리를 구현할 경우 모든 메소드를 구현 해야하므로,
          *  - UserDetails의 User객체를 이용하여 MemberEntity 체를 Spring Security의 UserDetails 객체로 변환한다.
          */
-        String grantedAuthority = "ROLE" + partnerEntity.getRoles();
-//        return new User(partnerEntity.getId(), partnerEntity.getPassword(), grantedAuthority));
         return new User(partnerEntity.getId(), partnerEntity.getPassword(), this.roleToAuthorities(partnerEntity.getRoles()));
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,10 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 ## JPA configuration
 spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+#spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# JPA Logging Configuration
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-type-value=refresh_token

--- a/src/test/java/io/auth/api/controller/PartnerControllerSuccessTest.java
+++ b/src/test/java/io/auth/api/controller/PartnerControllerSuccessTest.java
@@ -17,7 +17,7 @@ class PartnerControllerSuccessTest extends BaseTest {
 
     @Test
     @DisplayName("회원 생성 API")
-    public void createMemberAPI() throws Exception {
+    public void createPartnerAPI() throws Exception {
         // Given
         String id = "project062";
         String password = "chldydtjr1!";

--- a/src/test/java/io/auth/api/service/PartnerServiceImplFailTest.java
+++ b/src/test/java/io/auth/api/service/PartnerServiceImplFailTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-class PartnerServiceImplFailTest {
+class PartnerServiceFailTest {
 
     @Autowired
     PartnerService partnerService;

--- a/src/test/java/io/auth/api/service/PartnerServiceSuccessTest.java
+++ b/src/test/java/io/auth/api/service/PartnerServiceSuccessTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -17,9 +19,12 @@ class PartnerServiceSuccessTest {
     @Autowired
     PartnerService partnerService;
 
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
     @Test
     @DisplayName("회원 생성 Service")
-    public void createMemberService(){
+    public void createPartner(){
         // Given
         String id = "project.062";
         String password = "chldydtjr1!";
@@ -33,18 +38,26 @@ class PartnerServiceSuccessTest {
                 .partnerCompanyName(partnerCompanyName)
                 .build();
 
-        // When
-        ProcessingResult createdProcessingResult = this.partnerService.createPartner(partnerEntity);
+        partnerEntity.signUp();
 
-        // Then
+        // When : create Partner Account Entity
+        ProcessingResult createdProcessingResult = this.partnerService.createPartner(partnerEntity);
+        PartnerEntity createdPartnerEntity = (PartnerEntity) createdProcessingResult.getData();
+
+        // Then : check cre
         assertThat(createdProcessingResult).isNotNull();
         assertThat(createdProcessingResult.isSuccess()).isEqualTo(true);
         assertThat(createdProcessingResult.getData()).isNotNull();
-    }
 
-    @Test
-    public void findById(){
+        // When : Select Created Partner Account Entity
         UserDetailsService userDetailsService = partnerService;
+        UserDetails userDetails = userDetailsService.loadUserByUsername(id);
 
+        // Then
+        assertThat(createdPartnerEntity.getId()).matches(userDetails.getUsername());
+
+        // Then : partner password encoding chekc
+        PartnerEntity createPartnerEntity = (PartnerEntity) createdProcessingResult.getData();
+        assertThat(this.passwordEncoder.matches(password, createPartnerEntity.getPassword())).isTrue();
     }
 }


### PR DESCRIPTION
- ApplicationConfig
   - Application 관련 Bean 설정 부 분
 - Spring Security의 PasswordEncoder를 이용한 Bcript 암호화 적용
 - PartnerServiceSuccessTest.java -> createPartner() : 암호화 적용 여부 TC
 - 기타 불필요 코드 삭제 및 주석 추가
 - 파트너 계정 생성시 unique로 지정된 id 항목 중복 검사
 - email 항목 unique 속성 제거
 - 계정 생성 처리 중 오류 발생 시 500 Internal Server Error 응답 처리 추가
 - 코드 수정에 따른 TC 수정